### PR TITLE
feat: apply Prisma360 branding

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -110,8 +110,8 @@
 
 :root {
   /* Accent colors */
-  --brand: oklch(66.5% 0.1804 47.04);
-  --brand-foreground: oklch(75.77% 0.159 55.91);
+  --brand: #D97A0B;
+  --brand-foreground: #ffffff;
 
   /* Customized shadcn/ui colors */
   --background: oklch(97.65% 0.001 17.18);
@@ -120,8 +120,8 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(66.5% 0.1804 47.04);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: #0F2B59;
+  --primary-foreground: #ffffff;
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.967 0.001 286.375);
@@ -159,8 +159,8 @@
 
 .dark {
   /* Accent colors */
-  --brand: oklch(83.6% 0.1177 66.87);
-  --brand-foreground: oklch(75.77% 0.159 55.91);
+  --brand: #D97A0B;
+  --brand-foreground: #ffffff;
 
   /* Customized shadcn/ui colors */
   --background: oklch(0.141 0.005 285.823);
@@ -169,8 +169,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.141 0.005 285.823);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.21 0.006 285.885);
+  --primary: #0F2B59;
+  --primary-foreground: #ffffff;
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.274 0.006 286.033);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -108,9 +108,9 @@ export default function Home() {
             </div>
             
             <h1 className="text-5xl md:text-6xl font-bold">
-              Transformamos empresas con
+              Soluciones integrales para
               <span className="block mt-2 bg-gradient-to-r from-primary to-brand bg-clip-text text-transparent">
-                estrategias basadas en datos
+                decisiones estratégicas
               </span>
             </h1>
             

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -10,10 +10,10 @@ import {
   Twitter, 
   Facebook, 
   Instagram,
-  BarChart3,
   Send
 } from "lucide-react";
 import { useState } from "react";
+import Image from "next/image";
 
 const footerLinks = {
   servicios: [
@@ -77,10 +77,18 @@ export function Footer() {
           {/* Company Info */}
           <div className="lg:col-span-2 space-y-4">
             <div className="flex items-center space-x-2">
-              <BarChart3 className="h-8 w-8 text-primary" />
-              <span className="text-xl font-bold bg-gradient-to-r from-primary to-brand bg-clip-text text-transparent">
-                Consultoría Elite
-              </span>
+              {/* Placeholder logo. Replace `prisma360-logo.svg` with actual logo file. */}
+              <Image
+                src="/prisma360-logo.svg"
+                alt="Prisma360 Consultora logo"
+                width={32}
+                height={32}
+                className="h-8 w-8"
+              />
+              <div className="leading-tight">
+                <span className="block text-xl font-bold text-primary">prisma360</span>
+                <span className="block text-xs text-brand">consultora</span>
+              </div>
             </div>
             <p className="text-sm text-muted-foreground max-w-sm">
               Transformamos empresas mediante estrategias de crecimiento basadas en datos, 

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Menu, X, BarChart3, ChevronRight } from "lucide-react";
+import { Menu, X, ChevronRight } from "lucide-react";
+import Image from "next/image";
 import { cn } from "@/lib/utils";
 
 const navItems = [
@@ -53,10 +54,18 @@ export function Navigation() {
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <a href="#inicio" onClick={handleNavClick} className="flex items-center space-x-2">
-            <BarChart3 className="h-8 w-8 text-primary" />
-            <span className="text-xl font-bold bg-gradient-to-r from-primary to-brand bg-clip-text text-transparent">
-              Consultoría Elite
-            </span>
+            {/* Placeholder logo. Replace `prisma360-logo.svg` with actual logo file. */}
+            <Image
+              src="/prisma360-logo.svg"
+              alt="Prisma360 Consultora logo"
+              width={32}
+              height={32}
+              className="h-8 w-8"
+            />
+            <div className="leading-tight">
+              <span className="block text-xl font-bold text-primary">prisma360</span>
+              <span className="block text-xs text-brand">consultora</span>
+            </div>
           </a>
 
           {/* Desktop Navigation */}

--- a/public/prisma360-logo.svg
+++ b/public/prisma360-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="32" viewBox="0 0 120 32">
+  <rect width="120" height="32" fill="#CCCCCC"/>
+  <text x="60" y="21" font-family="sans-serif" font-size="14" text-anchor="middle" fill="#333333">Logo</text>
+</svg>


### PR DESCRIPTION
## Summary
- update theme colors to Prisma360 blue and orange
- add Prisma360 logo placeholder to navigation and footer
- revise hero headline for new branding

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c49e138c0c8332b2c4063f393a4354