### PR TITLE
Remove team section video placeholder

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -350,17 +350,6 @@ export default function Home() {
               </div>
             </div>
           </div>
-          <div className="container mt-12">
-            <div className="aspect-video w-full">
-              <iframe
-                className="w-full h-full rounded-lg"
-                src="https://www.youtube.com/embed/dQw4w9WgXcQ"
-                title="Presentación de Martín Latorre"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
-              />
-            </div>
-          </div>
         </Section>
 
         {/* FAQ Section */}


### PR DESCRIPTION
## Summary
- remove temporary YouTube embed from the team section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4ba87eae08332bf584f9666208e5c