### PR TITLE
feat: toggle optional sections via config

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import { Footer } from "@/components/footer";
 import { Stats } from "@/components/stats";
 import { FAQ } from "@/components/faq";
 import { CTA } from "@/components/cta";
+import { sectionsConfig } from "@/config/sections";
 import {
   LineChart,
   ClipboardList,
@@ -257,37 +258,43 @@ export default function Home() {
         </Section>
 
         {/* Stats Section */}
-        <Section id="estadisticas" className="bg-gradient-to-br from-primary/5 via-transparent to-brand/5">
-          <div className="text-center mb-12 space-y-4">
-            <h2 className="text-3xl md:text-4xl font-bold">Nuestros Logros</h2>
-            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Números que respaldan nuestra experiencia y compromiso con el éxito
-            </p>
-          </div>
-          <Stats />
-        </Section>
+        {sectionsConfig.stats && (
+          <Section id="estadisticas" className="bg-gradient-to-br from-primary/5 via-transparent to-brand/5">
+            <div className="text-center mb-12 space-y-4">
+              <h2 className="text-3xl md:text-4xl font-bold">Nuestros Logros</h2>
+              <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+                Números que respaldan nuestra experiencia y compromiso con el éxito
+              </p>
+            </div>
+            <Stats />
+          </Section>
+        )}
 
         {/* Testimonials Section */}
-        <Section id="testimonios">
-          <div className="text-center mb-12 space-y-4">
-            <h2 className="text-3xl md:text-4xl font-bold">Lo que dicen nuestros clientes</h2>
-            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Historias reales de transformación y éxito empresarial
-            </p>
-          </div>
-          <Testimonials />
-        </Section>
+        {sectionsConfig.testimonials && (
+          <Section id="testimonios">
+            <div className="text-center mb-12 space-y-4">
+              <h2 className="text-3xl md:text-4xl font-bold">Lo que dicen nuestros clientes</h2>
+              <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+                Historias reales de transformación y éxito empresarial
+              </p>
+            </div>
+            <Testimonials />
+          </Section>
+        )}
 
         {/* Success Stories Carousel */}
-        <Section id="casos-exito" className="bg-muted/30">
-          <div className="text-center mb-12 space-y-4">
-            <h2 className="text-3xl md:text-4xl font-bold">Casos de Éxito</h2>
-            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Transformaciones reales con resultados medibles y sostenibles
-            </p>
-          </div>
-          <Carousel />
-        </Section>
+        {sectionsConfig.successStories && (
+          <Section id="casos-exito" className="bg-muted/30">
+            <div className="text-center mb-12 space-y-4">
+              <h2 className="text-3xl md:text-4xl font-bold">Casos de Éxito</h2>
+              <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+                Transformaciones reales con resultados medibles y sostenibles
+              </p>
+            </div>
+            <Carousel />
+          </Section>
+        )}
 
         {/* Team Section */}
         <Section id="equipo">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -2,18 +2,19 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { 
-  Mail, 
-  Phone, 
-  MapPin, 
-  Linkedin, 
-  Twitter, 
-  Facebook, 
+import {
+  Mail,
+  Phone,
+  MapPin,
+  Linkedin,
+  Twitter,
+  Facebook,
   Instagram,
   Send
 } from "lucide-react";
 import { useState } from "react";
 import Image from "next/image";
+import { sectionsConfig } from "@/config/sections";
 
 const footerLinks = {
   servicios: [
@@ -26,8 +27,12 @@ const footerLinks = {
   empresa: [
     { label: "Sobre Nosotros", href: "#nosotros" },
     { label: "Nuestro Equipo", href: "#equipo" },
-    { label: "Casos de Éxito", href: "#casos-exito" },
-    { label: "Testimonios", href: "#testimonios" },
+    ...(sectionsConfig.successStories
+      ? [{ label: "Casos de Éxito", href: "#casos-exito" }]
+      : []),
+    ...(sectionsConfig.testimonials
+      ? [{ label: "Testimonios", href: "#testimonios" }]
+      : []),
     { label: "Blog", href: "#" },
   ],
   recursos: [

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -5,14 +5,14 @@ import { Button } from "@/components/ui/button";
 import { Menu, X, ChevronRight } from "lucide-react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
-
+import { sectionsConfig } from "@/config/sections";
 const navItems = [
   { href: "#inicio", label: "Inicio" },
   { href: "#servicios", label: "Servicios" },
   { href: "#nosotros", label: "Nosotros" },
-  { href: "#estadisticas", label: "Logros" },
-  { href: "#testimonios", label: "Testimonios" },
-  { href: "#casos-exito", label: "Casos de Éxito" },
+  ...(sectionsConfig.stats ? [{ href: "#estadisticas", label: "Logros" }] : []),
+  ...(sectionsConfig.testimonials ? [{ href: "#testimonios", label: "Testimonios" }] : []),
+  ...(sectionsConfig.successStories ? [{ href: "#casos-exito", label: "Casos de Éxito" }] : []),
   { href: "#equipo", label: "Equipo" },
   { href: "#faq", label: "FAQ" },
   { href: "#contacto", label: "Contacto" },

--- a/config/sections.ts
+++ b/config/sections.ts
@@ -1,0 +1,11 @@
+export interface SectionsConfig {
+  stats: boolean;
+  testimonials: boolean;
+  successStories: boolean;
+}
+
+export const sectionsConfig: SectionsConfig = {
+  stats: false,
+  testimonials: false,
+  successStories: false,
+};


### PR DESCRIPTION
## Summary
- allow toggling of stats, testimonials and success stories via `sectionsConfig`
- hide navigation and footer links for disabled sections

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d3f4d934833290b9b62d3492152d