### PR TITLE
Add pilares section with hexagon service map

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import { Footer } from "@/components/footer";
 import { Stats } from "@/components/stats";
 import { FAQ } from "@/components/faq";
 import { CTA } from "@/components/cta";
+import { Pilares } from "@/components/pilares";
 import { sectionsConfig } from "@/config/sections";
 import {
   LineChart,
@@ -171,7 +172,21 @@ export default function Home() {
           </div>
         </Section>
 
-        {/* About Section 
+        {/* Pillars Section */}
+        <Section id="pilares" className="bg-muted/30">
+          <div className="max-w-5xl mx-auto space-y-12">
+            <div className="text-center space-y-4">
+              <h2 className="text-3xl md:text-4xl font-bold">Pilares de éxito empresarial</h2>
+              <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+                Nuestra metodología integral conecta cada servicio para construir una visión
+                360° que impulsa el crecimiento sostenido de las organizaciones.
+              </p>
+            </div>
+            <Pilares />
+          </div>
+        </Section>
+
+        {/* About Section
         <Section id="nosotros" className="bg-muted/30">
           <div className="max-w-4xl mx-auto text-center space-y-6">
             <h2 className="text-3xl md:text-4xl font-bold">Crecimiento empresarial desde un enfoque integra</h2>

--- a/components/pilares.tsx
+++ b/components/pilares.tsx
@@ -1,0 +1,97 @@
+import Image from "next/image";
+import {
+  ClipboardList,
+  Leaf,
+  LineChart,
+  Settings,
+  Target,
+  Wallet,
+} from "lucide-react";
+
+const pillars = [
+  {
+    icon: LineChart,
+    title: "Planificación Económico Financiera",
+    position: { top: "6%", left: "50%" },
+  },
+  {
+    icon: ClipboardList,
+    title: "Outsourcing Administrativo",
+    position: { top: "26%", left: "87%" },
+  },
+  {
+    icon: Wallet,
+    title: "Administración Patrimonial",
+    position: { top: "74%", left: "87%" },
+  },
+  {
+    icon: Settings,
+    title: "Mejora de Procesos",
+    position: { top: "94%", left: "50%" },
+  },
+  {
+    icon: Leaf,
+    title: "Eficiencia Energética",
+    position: { top: "74%", left: "13%" },
+  },
+  {
+    icon: Target,
+    title: "Innovación Estratégica",
+    position: { top: "26%", left: "13%" },
+  },
+];
+
+export function Pilares() {
+  return (
+    <div className="relative w-full max-w-3xl mx-auto">
+      <div className="relative aspect-square">
+        <svg
+          viewBox="0 0 200 200"
+          className="w-full h-full text-primary/30"
+          aria-hidden="true"
+        >
+          <polygon
+            points="100,10 180,60 180,140 100,190 20,140 20,60"
+            fill="currentColor"
+            opacity={0.1}
+          />
+          <polygon
+            points="100,10 180,60 180,140 100,190 20,140 20,60"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="relative w-32 h-32 rounded-full bg-white shadow-xl flex items-center justify-center">
+            <Image
+              src="/logoPrisma360.png"
+              alt="Logo"
+              fill
+              sizes="128px"
+              className="object-contain p-3"
+            />
+          </div>
+        </div>
+
+        {pillars.map(({ icon: Icon, title, position }) => (
+          <div
+            key={title}
+            className="absolute flex flex-col items-center text-center -translate-x-1/2 -translate-y-1/2"
+            style={position}
+          >
+            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-primary/20 bg-white shadow-lg">
+              <Icon className="h-8 w-8 text-primary" />
+            </div>
+            <span className="mt-3 max-w-[8rem] text-xs font-semibold uppercase tracking-wide text-primary">
+              {title}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Pilares component that renders the six service icons around a hexagon with the company logo centered
- display the new component inside the "Pilares de éxito empresarial" section of the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c98fa93f188332b0d3ec163a7daf7e