### PR TITLE
Update CTA interactions and remove FAQ section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,6 @@ import { Testimonials } from "@/components/testimonials";
 import { Carousel } from "@/components/carousel";
 import { Footer } from "@/components/footer";
 import { Stats } from "@/components/stats";
-import { FAQ } from "@/components/faq";
 import { CTA } from "@/components/cta";
 import { Pilares } from "@/components/pilares";
 import { sectionsConfig } from "@/config/sections";
@@ -28,7 +27,6 @@ import {
   Leaf,
   Mail,
   ArrowRight,
-  Target,
   Sparkles,
   Users,
   CheckCircle
@@ -374,19 +372,8 @@ export default function Home() {
           </div>
         </Section>
 
-        {/* FAQ Section */}
-        <Section id="faq" className="bg-muted/30">
-          <div className="text-center mb-12 space-y-4">
-            <h2 className="text-3xl md:text-4xl font-bold">Preguntas Frecuentes</h2>
-            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Respuestas a las consultas más comunes sobre nuestros servicios
-            </p>
-          </div>
-          <FAQ />
-        </Section>
-
         {/* CTA Section */}
-        <Section>
+        <Section id="transformacion">
           <CTA />
         </Section>
 

--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -4,6 +4,16 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight, Calendar, Phone } from "lucide-react";
 
 export function CTA() {
+  const handleScheduleClick = () => {
+    window.location.href = `mailto:contacto@prisma360.com.ar?subject=${encodeURIComponent(
+      "Consulta",
+    )}`;
+  };
+
+  const handleCallClick = () => {
+    window.location.href = "tel:+541162315913";
+  };
+
   return (
     <div className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-primary via-brand to-primary p-8 md:p-12 text-center">
       {/* Background Pattern */}
@@ -19,18 +29,20 @@ export function CTA() {
         </p>
         
         <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
-          <Button 
-            size="lg" 
+          <Button
+            size="lg"
             className="bg-white text-primary hover:bg-white/90 font-semibold group"
+            onClick={handleScheduleClick}
           >
             <Calendar className="mr-2 h-5 w-5" />
             Agendar Consulta Gratuita
             <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
           </Button>
-          <Button 
-            size="lg" 
-            variant="outline" 
+          <Button
+            size="lg"
+            variant="outline"
             className="border-white text-white hover:bg-white/10 font-semibold"
+            onClick={handleCallClick}
           >
             <Phone className="mr-2 h-5 w-5" />
             Llamar Ahora

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -14,7 +14,6 @@ const navItems = [
   ...(sectionsConfig.testimonials ? [{ href: "#testimonios", label: "Testimonios" }] : []),
   ...(sectionsConfig.successStories ? [{ href: "#casos-exito", label: "Casos de Éxito" }] : []),
   { href: "#equipo", label: "Equipo" },
-  { href: "#faq", label: "FAQ" },
   { href: "#contacto", label: "Contacto" },
 ];
 
@@ -30,6 +29,14 @@ export function Navigation() {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  const handleCTAButtonClick = () => {
+    const ctaSection = document.querySelector("#transformacion");
+    if (ctaSection) {
+      ctaSection.scrollIntoView({ behavior: "smooth" });
+    }
+    setIsOpen(false);
+  };
 
   const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -79,7 +86,10 @@ export function Navigation() {
                 {item.label}
               </a>
             ))}
-            <Button className="ml-4 bg-gradient-to-r from-primary to-brand hover:opacity-90 transition-opacity">
+            <Button
+              onClick={handleCTAButtonClick}
+              className="ml-4 bg-gradient-to-r from-primary to-brand hover:opacity-90 transition-opacity"
+            >
               Consulta Gratuita
               <ChevronRight className="ml-2 h-4 w-4" />
             </Button>
@@ -112,7 +122,10 @@ export function Navigation() {
                 {item.label}
               </a>
             ))}
-            <Button className="mx-4 bg-gradient-to-r from-primary to-brand hover:opacity-90 transition-opacity">
+            <Button
+              onClick={handleCTAButtonClick}
+              className="mx-4 bg-gradient-to-r from-primary to-brand hover:opacity-90 transition-opacity"
+            >
               Consulta Gratuita
               <ChevronRight className="ml-2 h-4 w-4" />
             </Button>


### PR DESCRIPTION
## Summary
- remove the FAQ block and give the "¿Listo para transformar tu empresa?" call to action its own anchor for navigation
- point the "Consulta Gratuita" navigation button at the transformation section with smooth scrolling on desktop and mobile
- hook the CTA buttons up to mailto and tel links that reuse the contact email and phone number

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9976f65b48332806bb146c2f4dba4