### PR TITLE
Refresh Prisma palette across UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,14 @@
 
 @import "tw-animate-css";
 
+/* Prisma 360 color palette
+   Navy (primary)   — #1B2A4A
+   Teal (secondary) — #0A6F78
+   Orange (brand)   — #F47A32
+   Sky (accent)     — #06B4E0
+   Soft Sky (light) — #E3F5FB
+*/
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
@@ -110,8 +118,8 @@
 
 :root {
   /* Accent colors */
-  --brand: #D97A0B;
-  --brand-foreground: #ffffff;
+  --brand: #F47A32;
+  --brand-foreground: #04111d;
 
   /* Customized shadcn/ui colors */
   --background: oklch(97.65% 0.001 17.18);
@@ -120,24 +128,24 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: #0F2B59;
-  --primary-foreground: #ffffff;
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --primary: #1B2A4A;
+  --primary-foreground: #F6F8FB;
+  --secondary: #0A6F78;
+  --secondary-foreground: #ffffff;
   --muted: oklch(0.967 0.001 286.375);
   --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.927 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
+  --accent: #06B4E0;
+  --accent-foreground: #051927;
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.577 0.245 27.325);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
+  --chart-1: #1B2A4A;
+  --chart-2: #0A6F78;
+  --chart-3: #06B4E0;
+  --chart-4: #F47A32;
+  --chart-5: #133852;
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
@@ -149,8 +157,18 @@
   --sidebar-ring: oklch(0.705 0.015 286.067);
 
   /* Illustrations colors */
-  --light: var(--brand);
-  --light-foreground: var(--brand-foreground);
+  --light: #E3F5FB;
+  --light-foreground: #04111d;
+
+  /* Derived blends for gradients */
+  --primary-soft: color-mix(in oklab, var(--primary) 18%, white 82%);
+  --brand-soft: color-mix(in oklab, var(--brand) 16%, white 84%);
+  --accent-soft: color-mix(in oklab, var(--accent) 14%, white 86%);
+  --primary-accent-blend: color-mix(in oklab, var(--primary) 55%, var(--accent) 45%);
+  --primary-brand-blend: color-mix(in oklab, var(--primary) 48%, var(--brand) 52%);
+  --secondary-accent-blend: color-mix(in oklab, var(--secondary) 58%, var(--accent) 42%);
+  --primary-secondary-blend: color-mix(in oklab, var(--primary) 60%, var(--secondary) 40%);
+  --brand-accent-blend: color-mix(in oklab, var(--brand) 55%, var(--accent) 45%);
 
   /* Shadows */
   --shadow: #00000008;
@@ -159,8 +177,8 @@
 
 .dark {
   /* Accent colors */
-  --brand: #D97A0B;
-  --brand-foreground: #ffffff;
+  --brand: #F47A32;
+  --brand-foreground: #0b1219;
 
   /* Customized shadcn/ui colors */
   --background: oklch(0.141 0.005 285.823);
@@ -169,24 +187,24 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.141 0.005 285.823);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: #0F2B59;
-  --primary-foreground: #ffffff;
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
+  --primary: #1B2A4A;
+  --primary-foreground: #F1F5FA;
+  --secondary: #0A6F78;
+  --secondary-foreground: #E9FBFF;
   --muted: oklch(0.274 0.006 286.033);
   --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
+  --accent: #06B4E0;
+  --accent-foreground: #031019;
   --destructive: oklch(0.396 0.141 25.723);
   --destructive-foreground: oklch(0.637 0.237 25.331);
   --border: oklch(0.885 0.006 286.033);
   --input: oklch(0.274 0.006 286.033);
   --ring: oklch(0.442 0.017 285.786);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
+  --chart-1: #06B4E0;
+  --chart-2: #3AC0C8;
+  --chart-3: #F47A32;
+  --chart-4: #1B2A4A;
+  --chart-5: #0A6F78;
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -197,8 +215,18 @@
   --sidebar-ring: oklch(0.442 0.017 285.786);
 
   /* Illustrations colors */
-  --light: var(--foreground);
-  --light-foreground: var(--foreground);
+  --light: color-mix(in oklab, var(--accent) 45%, black 55%);
+  --light-foreground: #E3F5FB;
+
+  /* Derived blends for gradients */
+  --primary-soft: color-mix(in oklab, var(--primary) 38%, black 62%);
+  --brand-soft: color-mix(in oklab, var(--brand) 35%, black 65%);
+  --accent-soft: color-mix(in oklab, var(--accent) 42%, black 58%);
+  --primary-accent-blend: color-mix(in oklab, var(--primary) 45%, var(--accent) 55%);
+  --primary-brand-blend: color-mix(in oklab, var(--primary) 42%, var(--brand) 58%);
+  --secondary-accent-blend: color-mix(in oklab, var(--secondary) 52%, var(--accent) 48%);
+  --primary-secondary-blend: color-mix(in oklab, var(--primary) 54%, var(--secondary) 46%);
+  --brand-accent-blend: color-mix(in oklab, var(--brand) 50%, var(--accent) 50%);
 
   /* Shadows */
   --shadow: #00000020;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -120,7 +120,7 @@ const actionPlanSteps = [
     details: [
       "Procesamiento y análisis de la información suministrada.",
     ],
-    gradient: "from-[#12325A] to-[#1F4E8C]",
+    gradient: "from-[var(--primary)] via-[var(--primary-accent-blend)] to-[var(--accent)]",
   },
   {
     icon: ClipboardCheck,
@@ -129,14 +129,14 @@ const actionPlanSteps = [
     details: [
       "Acciones priorizadas según las necesidades primarias y secundarias.",
     ],
-    gradient: "from-[#B55F09] to-[#D97A0B]",
+    gradient: "from-[var(--brand)] via-[var(--brand-accent-blend)] to-[var(--accent)]",
   },
   {
     icon: BarChart3,
     title: "Desarrollo",
     description: "Elaboración y parametrización de reportes.",
     details: ["P&L, cash flow, budgets, pricing, KPIs, etc."],
-    gradient: "from-[#0F2B59] to-[#1A3F7A]",
+    gradient: "from-[var(--primary)] via-[var(--primary-brand-blend)] to-[var(--brand)]",
   },
   {
     icon: Rocket,
@@ -144,7 +144,7 @@ const actionPlanSteps = [
     description:
       "Implementación de los reportes consensuados adaptados a cada cliente.",
     details: ["Presentaciones semanales, mensuales y trimestrales."],
-    gradient: "from-[#175C8C] to-[#1E7FB7]",
+    gradient: "from-[var(--secondary)] via-[var(--secondary-accent-blend)] to-[var(--accent)]",
   },
   {
     icon: Radar,
@@ -153,7 +153,7 @@ const actionPlanSteps = [
     details: [
       "Identificación de oportunidades de mejora y automatización de procesos.",
     ],
-    gradient: "from-[#0B1F3D] to-[#12375F]",
+    gradient: "from-[var(--primary)] via-[var(--primary-secondary-blend)] to-[var(--secondary)]",
   },
 ];
 
@@ -213,7 +213,7 @@ export default function Home() {
         {/* Hero Section */}
         <Section id="inicio" className="relative min-h-[80vh] flex items-center justify-center text-center overflow-hidden">
           {/* Background Gradient */}
-          <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-brand/5" />
+          <div className="absolute inset-0 bg-gradient-to-br from-[color:var(--primary-soft)] via-transparent to-[color:var(--brand-soft)]" />
           
           <div className="relative z-10 max-w-4xl mx-auto space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-1000">
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium mb-4">
@@ -224,7 +224,7 @@ export default function Home() {
             
 
             <h1 className="text-5xl md:text-6xl font-bold">
-              <span className="block mt-2 bg-gradient-to-r from-primary to-brand bg-clip-text text-transparent">
+              <span className="block mt-2 bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] bg-clip-text text-transparent">
                 Pilares del éxito organizacional
               </span>
             </h1>
@@ -240,7 +240,7 @@ export default function Home() {
 
             {/*
             <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
-              <Button size="lg" className="bg-gradient-to-r from-primary to-brand hover:opacity-90 group">
+              <Button size="lg" className="bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 group">
                 Consulta Gratuita
                 <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
               </Button>
@@ -360,7 +360,7 @@ export default function Home() {
         {/* Action Plan Section */}
         <Section
           id="plan-accion"
-          className="bg-gradient-to-br from-primary/5 via-transparent to-brand/10"
+          className="bg-gradient-to-br from-[color:var(--primary-soft)] via-transparent to-[color:var(--accent-soft)]"
         >
           <div className="text-center mb-12 space-y-4">
             <h2 className="text-3xl md:text-4xl font-bold">Plan de Acción</h2>
@@ -387,7 +387,7 @@ export default function Home() {
 
         {/* Stats Section */}
         {sectionsConfig.stats && (
-          <Section id="estadisticas" className="bg-gradient-to-br from-primary/5 via-transparent to-brand/5">
+          <Section id="estadisticas" className="bg-gradient-to-br from-[color:var(--primary-soft)] via-transparent to-[color:var(--brand-soft)]">
             <div className="text-center mb-12 space-y-4">
               <h2 className="text-3xl md:text-4xl font-bold">Nuestros Logros</h2>
               <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
@@ -534,7 +534,7 @@ export default function Home() {
             
             <Button
               size="lg"
-              className="bg-gradient-to-r from-primary to-brand hover:opacity-90 group"
+              className="bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 group"
               onClick={() => {
                 const el = document.getElementById("transformacion");
                 if (el) {

--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -15,7 +15,7 @@ export function CTA() {
   };
 
   return (
-    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-primary via-brand to-primary p-8 md:p-12 text-center">
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-[var(--primary)] via-[var(--accent)] to-[var(--brand)] p-8 md:p-12 text-center">
       {/* Background Pattern */}
       <div className="absolute inset-0 bg-grid-white/10 [mask-image:radial-gradient(ellipse_at_center,transparent_20%,black)]" />
       

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -98,7 +98,7 @@ export function Footer() {
                   className="flex-1"
                   required
                 />
-                <Button type="submit" size="sm" className="bg-gradient-to-r from-primary to-brand hover:opacity-90 px-3">
+                <Button type="submit" size="sm" className="bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 px-3">
                   <Send className="h-4 w-4" />
                 </Button>
               </form>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -89,7 +89,7 @@ export function Navigation() {
             ))}
             <Button
               onClick={handleCTAButtonClick}
-              className="ml-4 bg-gradient-to-r from-primary to-brand hover:opacity-90 transition-opacity"
+              className="ml-4 bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 transition-opacity"
             >
               Consulta Gratuita
               <ChevronRight className="ml-2 h-4 w-4" />
@@ -125,7 +125,7 @@ export function Navigation() {
             ))}
             <Button
               onClick={handleCTAButtonClick}
-              className="mx-4 bg-gradient-to-r from-primary to-brand hover:opacity-90 transition-opacity"
+              className="mx-4 bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 transition-opacity"
             >
               Consulta Gratuita
               <ChevronRight className="ml-2 h-4 w-4" />

--- a/components/stats.tsx
+++ b/components/stats.tsx
@@ -59,7 +59,7 @@ function Counter({ end, suffix }: { end: number; suffix: string }) {
   }, [end]);
 
   return (
-    <span className="text-4xl font-bold bg-gradient-to-r from-primary to-brand bg-clip-text text-transparent">
+    <span className="text-4xl font-bold bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] bg-clip-text text-transparent">
       {count}{suffix}
     </span>
   );

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -93,7 +93,7 @@ export function Testimonials() {
                   className="h-10 w-10 rounded-full object-cover"
                 />
               ) : (
-                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-primary to-brand text-white font-semibold">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-[var(--primary)] to-[var(--brand)] text-white font-semibold">
                   {testimonial.image}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- document the Prisma 360 palette hex values and replace brand/primary/secondary/accent tokens in both themes, including chart colors and light aliases
- add blended color variables for gradients and update hero, CTA, and action-plan backgrounds to rely on the refreshed palette
- switch remaining gradient utilities in shared components to CSS variables for consistency with the new tones

## Testing
- npm run lint
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cd6eddc71c8332a409e88bb3ff4c23