### PR TITLE
feat: integrate Chronica Pro font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -43,7 +43,7 @@
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
 
-  --font-sans: var(--font-inter);
+  --font-sans: var(--font-chronica);
   --font-mono: var(--font-ibm-plex-mono);
 
   --radius-sm: calc(var(--radius) - 4px);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,19 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import localFont from "next/font/local";
+import { Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+const chronicaPro = localFont({
+  src: [
+    {
+      path: "../public/fonts/ChronicaPro-Medium.woff2",
+      weight: "500",
+      style: "normal",
+    },
+  ],
+  variable: "--font-chronica",
+  display: "swap",
+  fallback: ["Helvetica Neue", "Helvetica", "Arial", "sans-serif"],
 });
 
 const geistMono = Geist_Mono({
@@ -38,7 +47,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${chronicaPro.variable} ${geistMono.variable} antialiased`}
       >
         {children}
       </body>


### PR DESCRIPTION
## Summary
- load the Chronica Pro Medium webfont through `next/font/local`
- update the root layout and global CSS variables to expose the new sans-serif family
- remove the temporary `ChronicaPro-Medium.woff2` asset so it can be uploaded later

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd6ee348a48332bdaba49d68f1c0aa