### PR TITLE
Set hero heading color to brand navy

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -224,7 +224,7 @@ export default function Home() {
             
 
             <h1 className="text-5xl md:text-6xl font-bold">
-              <span className="block mt-2 bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] bg-clip-text text-transparent">
+              <span className="block mt-2 text-[#17384E]">
                 Pilares del éxito organizacional
               </span>
             </h1>


### PR DESCRIPTION
## Summary
- update the hero heading span to use the requested navy tone instead of the gradient

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7e7a2fcc8332a6c98c0d32bf7a78