### PR TITLE
Update consulta gratuita button colors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -534,7 +534,7 @@ export default function Home() {
             
             <Button
               size="lg"
-              className="bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 group"
+              className="bg-[#377987] hover:bg-[#2f6775] transition-colors group"
               onClick={() => {
                 const el = document.getElementById("transformacion");
                 if (el) {

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -89,7 +89,7 @@ export function Navigation() {
             ))}
             <Button
               onClick={handleCTAButtonClick}
-              className="ml-4 bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 transition-opacity"
+              className="ml-4 bg-[#377987] hover:bg-[#2f6775] transition-colors"
             >
               Consulta Gratuita
               <ChevronRight className="ml-2 h-4 w-4" />
@@ -125,7 +125,7 @@ export function Navigation() {
             ))}
             <Button
               onClick={handleCTAButtonClick}
-              className="mx-4 bg-gradient-to-r from-[var(--primary)] to-[var(--brand)] hover:opacity-90 transition-opacity"
+              className="mx-4 bg-[#377987] hover:bg-[#2f6775] transition-colors"
             >
               Consulta Gratuita
               <ChevronRight className="ml-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- update the navigation "Consulta Gratuita" buttons to use the teal brand color provided
- align the "Solicitar Consulta Gratuita" call-to-action button with the same teal background and hover color

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7eba712c8332a480bfda014cc5e2