### PR TITLE
Add toggle for pillar layout options

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,18 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { 
-  Mail, 
-  Phone, 
-  MapPin, 
-  Linkedin, 
-  Twitter, 
-  Facebook, 
-  Instagram,
-  Send
-} from "lucide-react";
-import { useState } from "react";
+import { Mail, Phone } from "lucide-react";
 import Image from "next/image";
 
 const footerLinks = {
@@ -38,18 +26,6 @@ const socialLinks = [
 ];*/}
 
 export function Footer() {
-  const [email, setEmail] = useState("");
-  const [subscribed, setSubscribed] = useState(false);
-
-  const handleSubscribe = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (email) {
-      setSubscribed(true);
-      setTimeout(() => setSubscribed(false), 3000);
-      setEmail("");
-    }
-  };
-
   const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     const href = e.currentTarget.getAttribute("href");
     if (href && href.startsWith("#")) {

--- a/components/pilares.tsx
+++ b/components/pilares.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Image from "next/image";
+import { useState } from "react";
 import {
   ClipboardList,
   Leaf,
@@ -6,6 +9,7 @@ import {
   Target,
   Wallet,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 const pillars = [
   {
@@ -33,58 +37,91 @@ const pillars = [
     title: "Innovación Estratégica",
     position: { top: "26%", left: "13%" },
   },
-];
+] as const;
 
 export function Pilares() {
+  const [viewMode, setViewMode] = useState<"diagram" | "cards">("diagram");
+
+  const toggleViewMode = () =>
+    setViewMode((prev) => (prev === "diagram" ? "cards" : "diagram"));
+
   return (
-  <div className="relative w-full max-w-3xl mx-auto mt-12">
-    <div className="relative aspect-square w-full max-w-3xl mx-auto sm:max-w-xl md:max-w-2xl lg:max-w-4xl xl:max-w-6xl" style={{ maxWidth: '100%', height: 'auto' }}>
-        <svg
-          viewBox="0 0 200 200"
-          className="w-full h-full text-primary/30"
-          aria-hidden="true"
-          style={{ maxWidth: '100%', height: 'auto' }}
-        >
-          <polygon
-            points="100,10 180,60 180,140 100,190 20,140 20,60"
-            fill="currentColor"
-            opacity={0.1}
-          />
-          <polygon
-            points="100,10 180,60 180,140 100,190 20,140 20,60"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="4"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="relative w-[60vw] max-w-[150px] h-[60vw] max-h-[150px] sm:w-[200px] sm:h-[200px] sm:max-w-[200px] sm:max-h-[200px] md:w-[250px] md:h-[250px] md:max-w-[250px] md:max-h-[250px] lg:w-[300px] lg:h-[300px] lg:max-w-[300px] lg:max-h-[300px] xl:w-[400px] xl:h-[400px] xl:max-w-[400px] xl:max-h-[400px] flex items-center justify-center">
-            <Image
-              src="/logoPrisma360.png"
-              alt="Logo"
-              fill
-              sizes="(max-width: 640px) 60vw, (min-width: 640px) 200px, (min-width: 768px) 250px, (min-width: 1024px) 300px, 150px"
-              className="object-contain p-3"
-            />
+    <div className="relative mx-auto mt-12 flex w-full max-w-3xl flex-col gap-6">
+      <div className="flex justify-end">
+        <Button onClick={toggleViewMode} variant="outline">
+          {viewMode === "diagram" ? "Ver como cards" : "Ver como diagrama"}
+        </Button>
+      </div>
+      {viewMode === "diagram" ? (
+        <div className="relative w-full max-w-3xl">
+          <div
+            className="relative mx-auto aspect-square w-full max-w-3xl sm:max-w-xl md:max-w-2xl lg:max-w-4xl xl:max-w-6xl"
+            style={{ maxWidth: "100%", height: "auto" }}
+          >
+            <svg
+              viewBox="0 0 200 200"
+              className="h-full w-full text-primary/30"
+              aria-hidden="true"
+              style={{ maxWidth: "100%", height: "auto" }}
+            >
+              <polygon
+                points="100,10 180,60 180,140 100,190 20,140 20,60"
+                fill="currentColor"
+                opacity={0.1}
+              />
+              <polygon
+                points="100,10 180,60 180,140 100,190 20,140 20,60"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="relative flex h-[60vw] max-h-[150px] w-[60vw] max-w-[150px] items-center justify-center sm:h-[200px] sm:w-[200px] sm:max-h-[200px] sm:max-w-[200px] md:h-[250px] md:w-[250px] md:max-h-[250px] md:max-w-[250px] lg:h-[300px] lg:w-[300px] lg:max-h-[300px] lg:max-w-[300px] xl:h-[400px] xl:w-[400px] xl:max-h-[400px] xl:max-w-[400px]">
+                <Image
+                  src="/logoPrisma360.png"
+                  alt="Logo"
+                  fill
+                  sizes="(max-width: 640px) 60vw, (min-width: 640px) 200px, (min-width: 768px) 250px, (min-width: 1024px) 300px, 150px"
+                  className="object-contain p-3"
+                />
+              </div>
+            </div>
+            {pillars.map(({ icon: Icon, title, position }) => (
+              <div
+                key={title}
+                className="absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center text-center"
+                style={position}
+              >
+                <div className="flex h-16 w-16 items-center justify-center rounded-full border border-primary/20 bg-white shadow-lg">
+                  <Icon className="h-8 w-8 text-primary" />
+                </div>
+                <span className="text-stroke-orange mt-3 max-w-[10rem] rounded px-2 py-1 text-xs font-semibold uppercase tracking-wide text-primary drop-shadow-lg">
+                  {title}
+                </span>
+              </div>
+            ))}
           </div>
         </div>
-        {pillars.map(({ icon: Icon, title, position }) => (
-          <div
-            key={title}
-            className="absolute flex flex-col items-center text-center -translate-x-1/2 -translate-y-1/2"
-            style={position}
-          >
-            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-primary/20 bg-white shadow-lg">
-              <Icon className="h-8 w-8 text-primary" />
+      ) : (
+        <div className="w-full space-y-4">
+          {pillars.map(({ icon: Icon, title }) => (
+            <div
+              key={title}
+              className="flex items-center gap-4 rounded-2xl border border-primary/10 bg-white/80 p-4 shadow-sm backdrop-blur"
+            >
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Icon className="h-7 w-7" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-base font-semibold text-primary sm:text-lg">{title}</h3>
+              </div>
             </div>
-            <span className="mt-3 max-w-[10rem] text-xs font-semibold uppercase tracking-wide text-primary px-2 py-1 rounded drop-shadow-lg text-stroke-orange">
-              {title}
-            </span>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a toggle button in the pillars section to switch between the diagram and stacked card layouts
- clean up unused footer imports and state now that the newsletter form is commented out

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd874b9b2c83329c407666e057df00