### PR TITLE
Default pillars to cards and update energy icon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,6 @@ import {
   ClipboardList,
   Wallet,
   Settings,
-  Leaf,
   Mail,
   ArrowRight,
   Sparkles,
@@ -35,6 +34,7 @@ import {
   BarChart3,
   Rocket,
   Radar,
+  Zap,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -96,7 +96,7 @@ const services = [
     ],
   },
   {
-    icon: Leaf,
+    icon: Zap,
     title: "EFICIENCIA ENERGÉTICA",
     description:
       "Reducimos costos energéticos mediante proyectos de eficiencia, auditorías y gestión continua.",

--- a/components/pilares.tsx
+++ b/components/pilares.tsx
@@ -4,10 +4,10 @@ import Image from "next/image";
 import { useState } from "react";
 import {
   ClipboardList,
-  Leaf,
   LineChart,
   Target,
   Wallet,
+  Zap,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -28,7 +28,7 @@ const pillars = [
     position: { top: "74%", left: "87%" },
   },
   {
-    icon: Leaf,
+    icon: Zap,
     title: "Eficiencia Energética",
     position: { top: "74%", left: "13%" },
   },
@@ -40,14 +40,14 @@ const pillars = [
 ] as const;
 
 export function Pilares() {
-  const [viewMode, setViewMode] = useState<"diagram" | "cards">("diagram");
+  const [viewMode, setViewMode] = useState<"diagram" | "cards">("cards");
 
   const toggleViewMode = () =>
     setViewMode((prev) => (prev === "diagram" ? "cards" : "diagram"));
 
   return (
     <div className="relative mx-auto mt-12 flex w-full max-w-3xl flex-col gap-6">
-      <div className="flex justify-end">
+      <div className="hidden">
         <Button onClick={toggleViewMode} variant="outline">
           {viewMode === "diagram" ? "Ver como cards" : "Ver como diagrama"}
         </Button>


### PR DESCRIPTION
## Summary
- default the pillars component to show the cards layout and hide the toggle button
- replace the efficiency service icon with a lightning-style Zap icon across the page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd8bbfcee88332a4150d6c3e3ff0bf